### PR TITLE
Place generated lenses directly into type instead of Lenses subclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,18 +81,15 @@ public partial record A(int Prop1, string Prop2);
 // Generated
 partial record A
 {
-	public static class Lenses
-	{
-		public static Lens<A, int> Prop1 { get; } = ...;
-		public static Lens<A, string> Prop2 { get; } = ...;
-	}
+	public static Lens<A, int> Prop1Lens { get; } = ...;
+	public static Lens<A, string> Prop2Lens { get; } = ...;
 }
 ```
 With this generator, the aforementioned example could be rewritten via
 ```csharp
-var lensAB = A.Lenses.PropB;
-var lensBC = B.Lenses.PropC;
-var lensCS = C.Lenses.Prop;
+var lensAB = A.PropBLens;
+var lensBC = B.PropCLens;
+var lensCS = C.PropLens;
 
 A instance = ...;
 A updatedA = lensAB.Compose(lensBC).Compose(lensCS).Set("my new value", instance);

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator.IntegrationTests/LensGenerationTests.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator.IntegrationTests/LensGenerationTests.cs
@@ -24,13 +24,13 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
     public sealed partial record class A { public required B PropB { get; init; } }
 
     [GenerateLenses]
-    public sealed partial record class B { public required C PropC {get; init;} }
+    public sealed partial record class B { public required C PropC { get; init; } }
 
     [GenerateLenses]
-    public sealed partial record class C { public required D PropD {get; init;} }
+    public sealed partial record class C { public required D PropD { get; init; } }
 
     [GenerateLenses]
-    public sealed partial record class D { public required string PropString {get; init;} }
+    public sealed partial record class D { public required string PropString { get; init; } }
 
     [GenerateLenses]
     public sealed partial record class PrimaryCtor(int PropertyInt, string PropertyString);
@@ -45,7 +45,7 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new MyRecordClass { RequiredIntProperty = 1 };
 
-            Assert.Equal(instance.RequiredIntProperty, MyRecordClass.Lenses.RequiredIntProperty.Get(instance));
+            Assert.Equal(instance.RequiredIntProperty, MyRecordClass.RequiredIntPropertyLens.Get(instance));
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new MyRecordClass { RequiredIntProperty = 1 };
 
-            var newInstance = MyRecordClass.Lenses.RequiredIntProperty.Set(5, instance);
+            var newInstance = MyRecordClass.RequiredIntPropertyLens.Set(5, instance);
 
             Assert.Equal(5, newInstance.RequiredIntProperty);
         }
@@ -63,7 +63,7 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new MyRecordClass { IntProperty = 5, RequiredIntProperty = 1 };
 
-            Assert.Equal(instance.IntProperty, MyRecordClass.Lenses.IntProperty.Get(instance));
+            Assert.Equal(instance.IntProperty, MyRecordClass.IntPropertyLens.Get(instance));
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new MyRecordClass { IntProperty = 1, RequiredIntProperty = -1 };
 
-            var newInstance = MyRecordClass.Lenses.IntProperty.Set(5, instance);
+            var newInstance = MyRecordClass.IntPropertyLens.Set(5, instance);
 
             Assert.Equal(5, newInstance.IntProperty);
         }
@@ -79,10 +79,10 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         [Fact]
         public void RecordClass_Set_KeepsOtherPropertyValues()
         {
-            const int newValue = int.MaxValue; 
+            const int newValue = int.MaxValue;
             var instance = new MyRecordClass { IntProperty = 1, RequiredIntProperty = -5 };
 
-            var newInstance = MyRecordClass.Lenses.IntProperty.Set(newValue, instance);
+            var newInstance = MyRecordClass.IntPropertyLens.Set(newValue, instance);
 
             Assert.Equal(instance with { IntProperty = newValue }, newInstance);
         }
@@ -92,10 +92,10 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new A { PropB = new B { PropC = new C { PropD = new D { PropString = "originalValue" } } } };
 
-            var originalValue = A.Lenses.PropB
-                .Compose(B.Lenses.PropC)
-                .Compose(C.Lenses.PropD)
-                .Compose(D.Lenses.PropString);
+            var originalValue = A.PropBLens
+                .Compose(B.PropCLens)
+                .Compose(C.PropDLens)
+                .Compose(D.PropStringLens);
 
             Assert.Equal(instance.PropB.PropC.PropD.PropString, originalValue.Get(instance));
             Assert.Equal("new value", originalValue.Set("new value", instance).PropB.PropC.PropD.PropString);
@@ -106,7 +106,7 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new PrimaryCtor(1, "some value");
 
-            Assert.Equal(instance.PropertyInt, PrimaryCtor.Lenses.PropertyInt.Get(instance));
+            Assert.Equal(instance.PropertyInt, PrimaryCtor.PropertyIntLens.Get(instance));
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new PrimaryCtor(1, "some value");
 
-            var newInstance = PrimaryCtor.Lenses.PropertyInt.Set(-3, instance);
+            var newInstance = PrimaryCtor.PropertyIntLens.Set(-3, instance);
 
             Assert.Equal(-3, newInstance.PropertyInt);
             Assert.Equal(instance.PropertyString, newInstance.PropertyString);
@@ -125,7 +125,7 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new PrimaryCtor(1, "some value");
 
-            Assert.Equal(instance.PropertyString, PrimaryCtor.Lenses.PropertyString.Get(instance));
+            Assert.Equal(instance.PropertyString, PrimaryCtor.PropertyStringLens.Get(instance));
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new PrimaryCtor(1, "some value");
 
-            var newInstance = PrimaryCtor.Lenses.PropertyString.Set("new value", instance);
+            var newInstance = PrimaryCtor.PropertyStringLens.Set("new value", instance);
 
             Assert.Equal("new value", newInstance.PropertyString);
             Assert.Equal(instance.PropertyInt, newInstance.PropertyInt);
@@ -144,7 +144,7 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new PrimaryCtorStruct(1, "some value");
 
-            Assert.Equal(instance.PropertyInt, PrimaryCtorStruct.Lenses.PropertyInt.Get(instance));
+            Assert.Equal(instance.PropertyInt, PrimaryCtorStruct.PropertyIntLens.Get(instance));
         }
 
         [Fact]
@@ -152,7 +152,7 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new PrimaryCtorStruct(1, "some value");
 
-            var newInstance = PrimaryCtorStruct.Lenses.PropertyInt.Set(-3, instance);
+            var newInstance = PrimaryCtorStruct.PropertyIntLens.Set(-3, instance);
 
             Assert.Equal(-3, newInstance.PropertyInt);
             Assert.Equal(instance.PropertyString, newInstance.PropertyString);
@@ -163,7 +163,7 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new PrimaryCtorStruct(1, "some value");
 
-            Assert.Equal(instance.PropertyString, PrimaryCtorStruct.Lenses.PropertyString.Get(instance));
+            Assert.Equal(instance.PropertyString, PrimaryCtorStruct.PropertyStringLens.Get(instance));
         }
 
         [Fact]
@@ -171,7 +171,7 @@ namespace ThorSoft.Optics.Generator.IntegrationTests
         {
             var instance = new PrimaryCtorStruct(1, "some value");
 
-            var newInstance = PrimaryCtorStruct.Lenses.PropertyString.Set("new value", instance);
+            var newInstance = PrimaryCtorStruct.PropertyStringLens.Set("new value", instance);
 
             Assert.Equal("new value", newInstance.PropertyString);
             Assert.Equal(instance.PropertyInt, newInstance.PropertyInt);

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordClass_PrimaryConstructorAndProperties#LensGenerator.TestClass.g.verified.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordClass_PrimaryConstructorAndProperties#LensGenerator.TestClass.g.verified.cs
@@ -4,29 +4,24 @@ namespace Test.Module;
 partial record class TestClass
 {
 
-    public static class Lenses
-    {
-
-        public static global::ThorSoft.Optics.Lens<TestClass, int> Property1 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestClass, int> Property1Lens { get; } =
             new global::ThorSoft.Optics.Lens<TestClass, int>(
                 static (instance) => instance.Property1,
                 static (value, instance) => instance with { Property1 = value });
 
-        public static global::ThorSoft.Optics.Lens<TestClass, string> Property2 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestClass, string> Property2Lens { get; } =
             new global::ThorSoft.Optics.Lens<TestClass, string>(
                 static (instance) => instance.Property2,
                 static (value, instance) => instance with { Property2 = value });
 
-        public static global::ThorSoft.Optics.Lens<TestClass, object> Propety3 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestClass, object> Propety3Lens { get; } =
             new global::ThorSoft.Optics.Lens<TestClass, object>(
                 static (instance) => instance.Propety3,
                 static (value, instance) => instance with { Propety3 = value });
 
-        public static global::ThorSoft.Optics.Lens<TestClass, int> DeclaredProperty1 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestClass, int> DeclaredProperty1Lens { get; } =
             new global::ThorSoft.Optics.Lens<TestClass, int>(
                 static (instance) => instance.DeclaredProperty1,
                 static (value, instance) => instance with { DeclaredProperty1 = value });
-
-    } // Lenses
 
 } // TestClass

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordClass_PrimaryConstructorWithManyParameter#LensGenerator.TestClass.g.verified.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordClass_PrimaryConstructorWithManyParameter#LensGenerator.TestClass.g.verified.cs
@@ -4,24 +4,19 @@ namespace Test.Module;
 partial record class TestClass
 {
 
-    public static class Lenses
-    {
-
-        public static global::ThorSoft.Optics.Lens<TestClass, int> Property1 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestClass, int> Property1Lens { get; } =
             new global::ThorSoft.Optics.Lens<TestClass, int>(
                 static (instance) => instance.Property1,
                 static (value, instance) => instance with { Property1 = value });
 
-        public static global::ThorSoft.Optics.Lens<TestClass, string> Property2 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestClass, string> Property2Lens { get; } =
             new global::ThorSoft.Optics.Lens<TestClass, string>(
                 static (instance) => instance.Property2,
                 static (value, instance) => instance with { Property2 = value });
 
-        public static global::ThorSoft.Optics.Lens<TestClass, object> Propety3 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestClass, object> Propety3Lens { get; } =
             new global::ThorSoft.Optics.Lens<TestClass, object>(
                 static (instance) => instance.Propety3,
                 static (value, instance) => instance with { Propety3 = value });
-
-    } // Lenses
 
 } // TestClass

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordClass_PrimaryConstructorWithSingleParameter#LensGenerator.TestClass.g.verified.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordClass_PrimaryConstructorWithSingleParameter#LensGenerator.TestClass.g.verified.cs
@@ -4,14 +4,9 @@ namespace Test.Module;
 partial record class TestClass
 {
 
-    public static class Lenses
-    {
-
-        public static global::ThorSoft.Optics.Lens<TestClass, int> Property { get; } =
+        public static global::ThorSoft.Optics.Lens<TestClass, int> PropertyLens { get; } =
             new global::ThorSoft.Optics.Lens<TestClass, int>(
                 static (instance) => instance.Property,
                 static (value, instance) => instance with { Property = value });
-
-    } // Lenses
 
 } // TestClass

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordClass_PublicCustomTypeProperty#LensGenerator.TestClass.g.verified.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordClass_PublicCustomTypeProperty#LensGenerator.TestClass.g.verified.cs
@@ -4,14 +4,9 @@ namespace Test.Module;
 partial record class TestClass
 {
 
-    public static class Lenses
-    {
-
-        public static global::ThorSoft.Optics.Lens<TestClass, Test.OtherModule.CustomType> TestProperty { get; } =
+        public static global::ThorSoft.Optics.Lens<TestClass, Test.OtherModule.CustomType> TestPropertyLens { get; } =
             new global::ThorSoft.Optics.Lens<TestClass, Test.OtherModule.CustomType>(
                 static (instance) => instance.TestProperty,
                 static (value, instance) => instance with { TestProperty = value });
-
-    } // Lenses
 
 } // TestClass

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordClass_PublicIntegerProperty#LensGenerator.TestClass.g.verified.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordClass_PublicIntegerProperty#LensGenerator.TestClass.g.verified.cs
@@ -4,14 +4,9 @@ namespace Test.Module;
 partial record class TestClass
 {
 
-    public static class Lenses
-    {
-
-        public static global::ThorSoft.Optics.Lens<TestClass, int> TestProperty { get; } =
+        public static global::ThorSoft.Optics.Lens<TestClass, int> TestPropertyLens { get; } =
             new global::ThorSoft.Optics.Lens<TestClass, int>(
                 static (instance) => instance.TestProperty,
                 static (value, instance) => instance with { TestProperty = value });
-
-    } // Lenses
 
 } // TestClass

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordStruct_PrimaryConstructorAndProperties#LensGenerator.TestStruct.g.verified.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordStruct_PrimaryConstructorAndProperties#LensGenerator.TestStruct.g.verified.cs
@@ -4,29 +4,24 @@ namespace Test.Module;
 partial record struct TestStruct
 {
 
-    public static class Lenses
-    {
-
-        public static global::ThorSoft.Optics.Lens<TestStruct, int> Property1 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestStruct, int> Property1Lens =>
             new global::ThorSoft.Optics.Lens<TestStruct, int>(
                 static (instance) => instance.Property1,
                 static (value, instance) => instance with { Property1 = value });
 
-        public static global::ThorSoft.Optics.Lens<TestStruct, string> Property2 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestStruct, string> Property2Lens =>
             new global::ThorSoft.Optics.Lens<TestStruct, string>(
                 static (instance) => instance.Property2,
                 static (value, instance) => instance with { Property2 = value });
 
-        public static global::ThorSoft.Optics.Lens<TestStruct, object> Propety3 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestStruct, object> Propety3Lens =>
             new global::ThorSoft.Optics.Lens<TestStruct, object>(
                 static (instance) => instance.Propety3,
                 static (value, instance) => instance with { Propety3 = value });
 
-        public static global::ThorSoft.Optics.Lens<TestStruct, int> DeclaredProperty1 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestStruct, int> DeclaredProperty1Lens =>
             new global::ThorSoft.Optics.Lens<TestStruct, int>(
                 static (instance) => instance.DeclaredProperty1,
                 static (value, instance) => instance with { DeclaredProperty1 = value });
-
-    } // Lenses
 
 } // TestStruct

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordStruct_PrimaryConstructorWithManyParameter#LensGenerator.TestStruct.g.verified.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordStruct_PrimaryConstructorWithManyParameter#LensGenerator.TestStruct.g.verified.cs
@@ -4,24 +4,19 @@ namespace Test.Module;
 partial record struct TestStruct
 {
 
-    public static class Lenses
-    {
-
-        public static global::ThorSoft.Optics.Lens<TestStruct, int> Property1 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestStruct, int> Property1Lens =>
             new global::ThorSoft.Optics.Lens<TestStruct, int>(
                 static (instance) => instance.Property1,
                 static (value, instance) => instance with { Property1 = value });
 
-        public static global::ThorSoft.Optics.Lens<TestStruct, string> Property2 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestStruct, string> Property2Lens =>
             new global::ThorSoft.Optics.Lens<TestStruct, string>(
                 static (instance) => instance.Property2,
                 static (value, instance) => instance with { Property2 = value });
 
-        public static global::ThorSoft.Optics.Lens<TestStruct, object> Propety3 { get; } =
+        public static global::ThorSoft.Optics.Lens<TestStruct, object> Propety3Lens =>
             new global::ThorSoft.Optics.Lens<TestStruct, object>(
                 static (instance) => instance.Propety3,
                 static (value, instance) => instance with { Propety3 = value });
-
-    } // Lenses
 
 } // TestStruct

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordStruct_PrimaryConstructorWithSingleParameter#LensGenerator.TestStruct.g.verified.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordStruct_PrimaryConstructorWithSingleParameter#LensGenerator.TestStruct.g.verified.cs
@@ -4,14 +4,9 @@ namespace Test.Module;
 partial record struct TestStruct
 {
 
-    public static class Lenses
-    {
-
-        public static global::ThorSoft.Optics.Lens<TestStruct, int> Property { get; } =
+        public static global::ThorSoft.Optics.Lens<TestStruct, int> PropertyLens =>
             new global::ThorSoft.Optics.Lens<TestStruct, int>(
                 static (instance) => instance.Property,
                 static (value, instance) => instance with { Property = value });
-
-    } // Lenses
 
 } // TestStruct

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordStruct_PublicCustomTypeProperty#LensGenerator.TestClass.g.verified.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordStruct_PublicCustomTypeProperty#LensGenerator.TestClass.g.verified.cs
@@ -4,14 +4,9 @@ namespace Test.Module;
 partial record struct TestClass
 {
 
-    public static class Lenses
-    {
-
-        public static global::ThorSoft.Optics.Lens<TestClass, Test.OtherModule.CustomType> TestProperty { get; } =
+        public static global::ThorSoft.Optics.Lens<TestClass, Test.OtherModule.CustomType> TestPropertyLens =>
             new global::ThorSoft.Optics.Lens<TestClass, Test.OtherModule.CustomType>(
                 static (instance) => instance.TestProperty,
                 static (value, instance) => instance with { TestProperty = value });
-
-    } // Lenses
 
 } // TestClass

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordStruct_PublicIntegerProperty#LensGenerator.TestClass.g.verified.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator.Tests/LensGeneratorTests.RecordStruct_PublicIntegerProperty#LensGenerator.TestClass.g.verified.cs
@@ -4,14 +4,9 @@ namespace Test.Module;
 partial record struct TestClass
 {
 
-    public static class Lenses
-    {
-
-        public static global::ThorSoft.Optics.Lens<TestClass, int> TestProperty { get; } =
+        public static global::ThorSoft.Optics.Lens<TestClass, int> TestPropertyLens =>
             new global::ThorSoft.Optics.Lens<TestClass, int>(
                 static (instance) => instance.TestProperty,
                 static (value, instance) => instance with { TestProperty = value });
-
-    } // Lenses
 
 } // TestClass

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator/Generation/Lenses/RecordToGenerate.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator/Generation/Lenses/RecordToGenerate.cs
@@ -4,6 +4,7 @@ namespace ThorSoft.Optics.Generator.Generation.Lenses
 {
     internal sealed record class RecordToGenerate : CodeGenerationRequest
     {
+        public required bool IsStructType { get; init; }
         public required string TypeName { get; init; }
         public required string TypeNamespace { get; init; }
         public required string TypeKind { get; init; }

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator/LensGenerator.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator/LensGenerator.cs
@@ -97,9 +97,6 @@ namespace ThorSoft.Optics.Generator
                     }
                 }
 
-                // TODO: generate a lens for all properties defined through primary constructors 
-                // on record types.
-
                 if (properties.Count == 0)
                 {
                     diagnostics.Add(DiagnosticsHelper.CreateNoLensesToGenerate(recordDeclarationSyntax));
@@ -107,9 +104,10 @@ namespace ThorSoft.Optics.Generator
 
                 return new RecordToGenerate
                 {
+                    IsStructType = recordDeclarationSyntax.IsStruct(),
                     TypeName = recordDeclarationSyntax.Identifier.Text,
                     TypeNamespace = recordTypeSymbol.ContainingNamespace.ToString(),
-                    TypeKind = recordDeclarationSyntax.ClassOrStructKeyword.ToString(),
+                    TypeKind = recordDeclarationSyntax.ClassOrStructKeyword.ValueText,
                     Properties = new EquatableMemory<LensToGenerate>(properties.Extract()),
                     Diagnostics = new EquatableMemory<Diagnostic>(diagnostics.Extract())
                 };

--- a/ThorSoft.Optics/ThorSoft.Optics.Generator/Syntax/SyntaxExtensions.cs
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator/Syntax/SyntaxExtensions.cs
@@ -48,12 +48,6 @@ namespace ThorSoft.Optics.Generator.Syntax
         }
 
         /// <summary>
-        ///     Checks if the given <see cref="PropertyDeclarationSyntax"/> refers to a static property.
-        /// </summary>
-        public static bool IsStaticProperty(this PropertyDeclarationSyntax property) =>
-            property.HasModifierKind(SyntaxKind.StaticKeyword);
-
-        /// <summary>
         ///     Checks if the given <see cref="SyntaxNode"/> refers to a method invocation with method name <paramref name="methodName"/>.
         /// </summary>
         public static bool IsMethodInvocation(this SyntaxNode node, string methodName) =>
@@ -65,6 +59,22 @@ namespace ThorSoft.Optics.Generator.Syntax
                 }
             }
             && candidateMethodName == methodName;
+
+        /// <summary>
+        ///     Checks if the given <see cref="PropertyDeclarationSyntax"/> refers to a static property.
+        /// </summary>
+        public static bool IsStaticProperty(this PropertyDeclarationSyntax property) =>
+            property.HasModifierKind(SyntaxKind.StaticKeyword);
+
+        /// <summary>
+        ///     Checks if the given <see cref="RecordDeclarationSyntax"/> declares a <c>struct</c> record.
+        /// </summary>
+        public static bool IsStruct(this RecordDeclarationSyntax declaration) =>
+            declaration.ClassOrStructKeyword.ValueText switch
+            {
+                "struct" => true,
+                _ => false
+            };
 
         /// <summary>
         ///     Checks if the given <see cref="PropertyDeclarationSyntax"/> has a get-accessor.


### PR DESCRIPTION
The `Lenses` subtype approach has issues when dealing with properties with certain access modifiers, such as `private` properties, which would generate:
```csharp
[GenerateLenses]
partial record A
{
    private required int Property { get; init; }
}

// Generated
partial record A
{
    public static class Lenses
    {
        private Lens<A, int> Property { get; } = ...; // Unusable Lens
    }
}
```

Instead, the generated code is now
```csharp
// Generated
partial record A
{
    private static Lens<A, int> PropertyLens { get; } = ...;
}
```