### PR TITLE
Fix ProjectReference to Optics.csproj in Optics.IntegrationTests.csproj

### DIFF
--- a/ThorSoft.Optics/ThorSoft.Optics.Generator.IntegrationTests/ThorSoft.Optics.Generator.IntegrationTests.csproj
+++ b/ThorSoft.Optics/ThorSoft.Optics.Generator.IntegrationTests/ThorSoft.Optics.Generator.IntegrationTests.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ThorSoft.Optics.Generator\ThorSoft.Optics.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ThorSoft.Optics.Tests\ThorSoft.Optics.Tests.csproj" />
-    <ProjectReference Include="..\ThorSoft.Optics\ThorSoft.Optics.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
+    <ProjectReference Include="..\ThorSoft.Optics\ThorSoft.Optics.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For some reason the reference was marked as Analyzer="true"...